### PR TITLE
Depend on Stately CLI directly from the MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,38 @@ A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that i
 
 ## Prerequisites
 
-- **Node.js**: Version 16.0.0 or higher
-- **Stately CLI**: Make sure the `stately` command is available in your PATH:
-
-```bash
-curl -sL https://stately.cloud/install | sh
-```
+- **Node.js**: Version 20 or higher
 
 ## Installation
 
-### From npm registry
+## Configuring for Claude Code
+
+Run `claude mcp add statelydb -- npx -y @stately-cloud/statelydb-mcp-server@latest` to add the MCP server to your Claude Code.
+
+## Configuring with Claude Desktop
+
+To use this MCP server with Claude Desktop, follow these steps:
+
+1. Open your Claude Desktop App configuration file:
+   - **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+   - **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+2. Add the server configuration to the `mcpServers` section:
+
+```json
+{
+  "mcpServers": {
+    "statelydb": {
+      "command": "npx",
+      "args": ["-y", "@stately-cloud/statelydb-mcp-server@latest"]
+    }
+  }
+}
+```
+
+3. Save the file and restart Claude Desktop.
+
+## Manually install from npm registry
 
 Install the server globally:
 
@@ -24,10 +46,10 @@ npm install -g @stately-cloud/statelydb-mcp-server
 Alternatively, you can run it directly with npx:
 
 ```bash
-npx @stately-cloud/statelydb-mcp-server
+npx @stately-cloud/statelydb-mcp-server@latest
 ```
 
-### From local source
+## From local source
 
 To install directly from your local source code:
 
@@ -53,29 +75,6 @@ To unlink later, you can run:
 ```bash
 npm unlink statelydb-mcp-server
 ```
-
-## Configuring with Claude Desktop
-
-To use this MCP server with Claude Desktop, follow these steps:
-
-1. Open your Claude Desktop App configuration file:
-   - **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
-   - **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
-
-2. Add the server configuration to the `mcpServers` section:
-
-```json
-{
-  "mcpServers": {
-    "statelydb": {
-      "command": "npx",
-      "args": ["-y", "@stately-cloud/statelydb-mcp-server"]
-    }
-  }
-}
-```
-
-3. Save the file and restart Claude Desktop.
 
 ## Available Tools
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
     "name": "@stately-cloud/statelydb-mcp-server",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@stately-cloud/statelydb-mcp-server",
-            "version": "0.1.0",
+            "version": "1.0.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@modelcontextprotocol/sdk": "^1.5.0",
+                "@stately-cloud/cli": "^0.82.1",
                 "zod": "^3.22.4"
             },
             "bin": {
@@ -42,6 +43,19 @@
             },
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/@stately-cloud/cli": {
+            "version": "0.82.1",
+            "resolved": "https://registry.npmjs.org/@stately-cloud/cli/-/cli-0.82.1.tgz",
+            "integrity": "sha512-DTxSkdmllzulajZcau7/OGU+X0We/tjql5waahFDP4UfnJ/VkMDFNrji0HyOg9grPx+/Llivpwapx6gSR6dHOw==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "stately": "bin/stately.js"
+            },
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/@types/node": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "license": "Apache-2.0",
     "dependencies": {
         "@modelcontextprotocol/sdk": "^1.5.0",
+        "@stately-cloud/cli": "^0.82.1",
         "zod": "^3.22.4"
     },
     "devDependencies": {


### PR DESCRIPTION
This packs in the CLI so you don't need to install it separately. I also updated the README to make installation easier (Claude Code focused) and to force usage of the latest server version (otherwise npx will just stick with whatever you last installed).